### PR TITLE
docs: add concise background section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # A Copier Template to augment github repos with AI capabilities
 
-This template uses the code-scaffolding tool [copier](https://copier.readthedocs.io/) to ...
+This template uses the code-scaffolding tool [copier](https://copier.readthedocs.io/) to automatically set up AI-powered GitHub Actions in any existing repository.
+
+## What it does
+
+- **AI Issue Management**: Automatically responds to GitHub issues using AI agents
+- **Intelligent PR Reviews**: AI-powered code review and suggestions  
+- **Smart Documentation**: AI assistance for documentation updates and maintenance
+- **Automated Workflows**: Sets up GitHub Actions that understand and respond to natural language requests
+
+The repository follows a "meta" pattern - it uses its own template to provide AI capabilities (eating its own dogfood). Template files are in `template/` while other files are for this repo itself.
 
 For more background, please see:
 


### PR DESCRIPTION
Added concise background information to README explaining:
- AI capabilities (issue management, PR reviews, documentation, workflows)
- Meta pattern (eating own dogfood)
- Distinction between template/ and repo files

Closes #2

Generated with [Claude Code](https://claude.ai/code)