### PR TITLE
Update GitHub Actions versions to latest stable releases

### DIFF
--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    # Limit the number of open pull requests for version updates
+    open-pull-requests-limit: 5
+    # Add conventional commit prefixes
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    # Add reviewers (customize as needed)
+    # reviewers:
+    #   - "your-username"
+    # Add assignees (customize as needed)
+    # assignees:
+    #   - "your-username"

--- a/template/.github/workflows/dragon-ai.yml
+++ b/template/.github/workflows/dragon-ai.yml
@@ -29,7 +29,7 @@ jobs:
         
       - name: Check for qualifying mention
         id: check
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PAT_FOR_PR }}  # Use PAT instead of default token
           script: |
@@ -115,7 +115,7 @@ jobs:
         run: mkdir -p ${{ env.TOOLS_DIR }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
 


### PR DESCRIPTION
Updates GitHub Actions versions in the template to prevent dependabot complaints when users create new repositories from this template.

## Changes
- Updated `actions/github-script` from v6 to v8
- Updated `actions/setup-node` from v3 to v6
- Added `dependabot.yml` template for automated dependency updates

Resolves #16

Generated with [Claude Code](https://claude.ai/code)